### PR TITLE
[Do Not Merge] Dockerify dicpick

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:2.7
+ENV PYTHONUNBUFFERED 1
+RUN apt-get update
+RUN apt-get -y install wget zip gcc
+RUN mkdir /code
+WORKDIR /code
+ADD requirements.txt /code/
+RUN pip install -r requirements.txt
+ADD . /code/
+RUN ./bootstrap.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '2'
+services:
+  db:
+    image: postgres
+    environment:
+      POSTGRES_DB: dicpick
+      POSTGRES_USER: dicpick
+      POSTGRES_PASSWORD: dicpick
+    expose:
+      - "5432"
+    ports:
+      - "5432:5432"
+  web:
+    build: .
+    command: python manage.py runserver 0.0.0.0:8000
+    volumes:
+      - .:/code
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db

--- a/main/settings_dev.py
+++ b/main/settings_dev.py
@@ -29,7 +29,7 @@ DATABASES = {
         'NAME': 'dicpick',
         'USER': 'dicpick',
         'PASSWORD': DEFAULT_DATABASE_PASSWORD,
-        'HOST': '127.0.0.1',
+        'HOST': 'db' or '127.0.0.1',
         'PORT': '5432',
     }
 }


### PR DESCRIPTION
I tried to make a few changes as possible to the existing base. Since the dev settings import the local settings (which I think should be reversed) I had to change the default database host. We should expose those settings in the environment so they're more easily configurable (especially across environments e.g. local, prod, etc.)

TODO: Fix ProgrammingError at /accounts/login/

```
ProgrammingError at /accounts/login/
relation "django_site" does not exist
LINE 1: ..."django_site"."domain", "django_site"."name" FROM "django_si...
```

I cannot migrate:

```
➜  dicpick git:(dockerify) docker-compose run web manage.py migrate
Starting dicpick_db_1
ERROR: Cannot start service web: oci runtime error: container_linux.go:247: starting container process caused "exec: \"manage.py\": executable file not found in $PATH"
```